### PR TITLE
chore: 커밋 메세지 이슈 번호 추출 (#1)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @ydw1996 @ujinsim

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,11 +1,18 @@
-# 현재 브랜치 이름 가져오기
-branch_name=$(git symbolic-ref --short HEAD)
+# 현재 브랜치 이름 가져오기 (detached HEAD 상태면 에러 무시)
+branch_name=$(git symbolic-ref --short HEAD 2>/dev/null)
+
+# detached HEAD 상태면 커밋 메시지 수정 없이 종료
+if [ -z "$branch_name" ]; then
+  exit 0
+fi
 
 # 브랜치명에서 이슈 번호 추출 (예: feat/#3 -> 3)
 if [[ $branch_name =~ \#([0-9]+)$ ]]; then
   issue_number=${BASH_REMATCH[1]}
   commit_file=$1
   commit_message=$(cat "$commit_file")
+
+  # 커밋 메시지에 이미 이슈 번호가 포함되어 있지 않으면 추가
   if [[ ! $commit_message =~ \(\#$issue_number\) ]]; then
     echo "$commit_message (#$issue_number)" > "$commit_file"
   fi

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -20,8 +20,8 @@ fi
 if [ -n "$ISSUE_NUMBER" ]; then
   FORMATTED_ISSUE="($ISSUE_NUMBER)"
   echo "$COMMIT_MSG $FORMATTED_ISSUE" > "$COMMIT_MSG_FILE"
-  echo "🆕 커밋 메시지에 이슈 번호 $FORMATTED_ISSUE 추가됨"
+  echo "✅ 이슈 번호 $FORMATTED_ISSUE 커밋 메시지에 추가됨"
 else
   echo "$COMMIT_MSG (no-issue)" > "$COMMIT_MSG_FILE"
-  echo "⚠️ 이슈 번호를 찾을 수 없어 (no-issue) 추가됨"
+  echo "ℹ️ 이슈 번호가 없어 (no-issue) 추가됨"
 fi

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,12 @@
+# 현재 브랜치 이름 가져오기
+branch_name=$(git symbolic-ref --short HEAD)
+
+# 브랜치명에서 이슈 번호 추출 (예: feat/#3 -> 3)
+if [[ $branch_name =~ \#([0-9]+)$ ]]; then
+  issue_number=${BASH_REMATCH[1]}
+  commit_file=$1
+  commit_message=$(cat "$commit_file")
+  if [[ ! $commit_message =~ \(\#$issue_number\) ]]; then
+    echo "$commit_message (#$issue_number)" > "$commit_file"
+  fi
+fi

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,19 +1,27 @@
-# 현재 브랜치 이름 가져오기 (detached HEAD 상태면 에러 무시)
-branch_name=$(git symbolic-ref --short HEAD 2>/dev/null)
-
-# detached HEAD 상태면 커밋 메시지 수정 없이 종료
-if [ -z "$branch_name" ]; then
+# 현재 브랜치명 가져오기 (detached HEAD 상태 처리)
+BRANCH_NAME=$(git branch --show-current 2>/dev/null)
+if [ -z "$BRANCH_NAME" ]; then
   exit 0
 fi
 
-# 브랜치명에서 이슈 번호 추출 (예: feat/#3 -> 3)
-if [[ $branch_name =~ \#([0-9]+)$ ]]; then
-  issue_number=${BASH_REMATCH[1]}
-  commit_file=$1
-  commit_message=$(cat "$commit_file")
+# 브랜치명에서 #숫자 추출
+ISSUE_NUMBER=$(echo "$BRANCH_NAME" | grep -o '#[0-9]*' || echo "")
 
-  # 커밋 메시지에 이미 이슈 번호가 포함되어 있지 않으면 추가
-  if [[ ! $commit_message =~ \(\#$issue_number\) ]]; then
-    echo "$commit_message (#$issue_number)" > "$commit_file"
-  fi
+# 커밋 메시지 경로 및 내용
+COMMIT_MSG_FILE=$1
+COMMIT_MSG=$(cat "$COMMIT_MSG_FILE" 2>/dev/null || exit 1)
+
+# 이미 (#숫자) 형태가 있으면 그대로 둠
+if echo "$COMMIT_MSG" | grep -q "(#[0-9]*)"; then
+  exit 0
+fi
+
+# 이슈 번호 있으면 (#숫자) 붙임
+if [ -n "$ISSUE_NUMBER" ]; then
+  FORMATTED_ISSUE="($ISSUE_NUMBER)"
+  echo "$COMMIT_MSG $FORMATTED_ISSUE" > "$COMMIT_MSG_FILE"
+  echo "🆕 커밋 메시지에 이슈 번호 $FORMATTED_ISSUE 추가됨"
+else
+  echo "$COMMIT_MSG (no-issue)" > "$COMMIT_MSG_FILE"
+  echo "⚠️ 이슈 번호를 찾을 수 없어 (no-issue) 추가됨"
 fi


### PR DESCRIPTION
## 🚀 기능 추가

커밋 메시지에 자동으로 브랜치명 기반 이슈 번호(#n)를 추가하는 Git hook 스크립트 구현
CODEOWNERS 파일 추가로 자동 리뷰어 설정

## 🏗 작업 내용 

	•	커밋 시점의 브랜치명을 기준으로 이슈 번호 추출 (feat/#10 → #10)
	•	커밋 메시지에 (#10) 이 포함되어 있지 않으면 자동으로 덧붙이도록 처리
	•	Git hook에서 commit-msg 단계에서 실행되도록 스크립트 작성
	•	CODEOWNERS 파일 추가로 자동 리뷰어 설정

## 🔍 테스트 방법 | 🧪 테스트 체크리스트 

	1.	브랜치명을 feat/#1 생성
	2.	커밋 메시지에 (#1)을 쓰지 않고 커밋
	3.	자동으로 (#1)이 메시지 끝에 붙는지 확인
	4.	이미 (#1)이 포함된 경우 중복 추가되지 않는지 확인

## 👀 관련 이슈 번호

#1 

- close #

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Introduced an automated process to append the relevant issue number to Git commit messages based on the branch name, ensuring consistent tagging of commits.
  * Added a code ownership file to automatically request reviews from designated team members on all pull requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->