### PR TITLE
chore : 깃허브 라벨 설정 (#3)

### DIFF
--- a/labels.json
+++ b/labels.json
@@ -1,0 +1,62 @@
+[
+  {
+    "name": "⚙ Setting",
+    "color": "e3dede",
+    "description": "개발 환경 세팅"
+  },
+  {
+    "name": "✨ Feature",
+    "color": "a2eeef",
+    "description": "기능 개발"
+  },
+  {
+    "name": "🌏 Deploy",
+    "color": "C2E0C6",
+    "description": "배포 관련"
+  },
+  {
+    "name": "🎨 Html&css",
+    "color": "FEF2C0",
+    "description": "마크업 & 스타일링"
+  },
+  {
+    "name": "🐞 BugFix",
+    "color": "d73a4a",
+    "description": "Something isn't working"
+  },
+  {
+    "name": "💻 CrossBrowsing",
+    "color": "C5DEF5",
+    "description": "브라우저 호환성"
+  },
+  {
+    "name": "📃 Docs",
+    "color": "1D76DB",
+    "description": "문서 작성 및 수정 (README.md 등)"
+  },
+  {
+    "name": "📬 API",
+    "color": "D4C5F9",
+    "description": "서버 API 통신"
+  },
+  {
+    "name": "🔨 Refactor",
+    "color": "f29a4e",
+    "description": "코드 리팩토링"
+  },
+  {
+    "name": "🙋‍♂️ Question",
+    "color": "9ED447",
+    "description": "Further information is requested"
+  },
+  {
+    "name": "🥰 Accessibility",
+    "color": "facfcf",
+    "description": "웹접근성 관련"
+  },
+  {
+    "name": "✅ Test",
+    "color": "ccffc4",
+    "description": "test 관련(storybook, jest...)"
+  }
+]


### PR DESCRIPTION
## 🚀 초기 설정 
-  github label 적용

## 🏗 작업 내용

- [x]  github label 적용

<img width="725" height="501" alt="스크린샷 2025-08-01 오후 6 52 32" src="https://github.com/user-attachments/assets/17a01c2d-aed9-4168-8d78-e5439d1f7f68" />



## 👀 관련 이슈 번호

- close #3 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a comprehensive set of labels to help categorize issues and pull requests by topic, such as development, deployment, bug fixes, documentation, accessibility, and testing. Each label includes a color and description for easier identification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->