### PR TITLE
[FEAT] 모달 컴포넌트 제작 

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -2,8 +2,11 @@ import storybook from 'eslint-plugin-storybook';
 import { dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { FlatCompat } from '@eslint/eslintrc';
-import filenames from 'eslint-plugin-filenames';
 import importPlugin from 'eslint-plugin-import';
+import tsPlugin from '@typescript-eslint/eslint-plugin';
+import tsParser from '@typescript-eslint/parser';
+import prettierPlugin from 'eslint-plugin-prettier';
+import nextPlugin from '@next/eslint-plugin-next';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -15,41 +18,37 @@ const compat = new FlatCompat({
 const eslintConfig = [
   {
     languageOptions: {
-      parser: '@typescript-eslint/parser',
+      parser: tsParser,
+      parserOptions: {
+        ecmaVersion: 2020,
+        sourceType: 'module',
+      },
+    },
+    plugins: {
+      next: nextPlugin,
+      '@typescript-eslint': tsPlugin,
+      prettier: prettierPlugin,
     },
     rules: {
-      '@next/next/no-img-element': 'error',
+      'next/no-img-element': 'error',
       '@typescript-eslint/no-unused-vars': 'warn',
       '@typescript-eslint/explicit-module-boundary-types': 'warn',
+      'prettier/prettier': 'error',
     },
   },
   ...storybook.configs['flat/recommended'],
   {
     plugins: {
-      filenames,
       import: importPlugin,
     },
     rules: {
-      'filenames/match-regex': ['error', '^[a-z0-9-]+$', true],
-      'filenames/match-exported': ['error', 'pascalCase'],
       'import/order': [
         'error',
         {
-          groups: [
-            ['builtin', 'external'],
-            ['internal'],
-            ['sibling', 'parent'],
-            ['index'],
-          ],
+          groups: [['builtin', 'external'], ['internal'], ['sibling', 'parent'], ['index']],
           'newlines-between': 'always',
         },
       ],
-    },
-  },
-  {
-    plugins: ['@typescript-eslint', 'prettier'],
-    rules: {
-      'prettier/prettier': 'error',
     },
   },
 ];

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "devDependencies": {
     "@chromatic-com/storybook": "^4.0.1",
     "@eslint/eslintrc": "^3",
+    "@next/eslint-plugin-next": "^15.4.6",
     "@storybook/addon-docs": "^9.0.18",
     "@storybook/addon-onboarding": "^9.0.18",
     "@storybook/blocks": "^8.6.14",

--- a/public/assets/ico-alert.svg
+++ b/public/assets/ico-alert.svg
@@ -1,0 +1,5 @@
+<svg width="56" height="56" viewBox="0 0 56 56" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="28" cy="28" r="28" fill="#E6E6E6"/>
+<rect x="25" y="15" width="6" height="16" rx="3" fill="white"/>
+<rect x="25" y="35" width="6" height="6" rx="3" fill="white"/>
+</svg>

--- a/src/components/ui/Button/Button.stories.tsx
+++ b/src/components/ui/Button/Button.stories.tsx
@@ -1,5 +1,4 @@
 import type { Meta, StoryObj } from '@storybook/nextjs';
-
 import { fn } from 'storybook/test';
 
 import { Button } from './Button';

--- a/src/components/ui/Modal/Modal.stories.tsx
+++ b/src/components/ui/Modal/Modal.stories.tsx
@@ -1,0 +1,55 @@
+import type { Meta, StoryObj } from '@storybook/nextjs';
+import Image from 'next/image';
+
+import { Modal } from './Modal';
+
+import useModal from '@/hooks/useModal';
+
+export default {
+  title: 'components/common/Modal',
+  component: Modal,
+  tags: ['autodocs'],
+} satisfies Meta<typeof Modal>;
+
+export const Basic: StoryObj<typeof Modal> = {
+  args: { isOpen: false },
+  render: (args) => {
+    const { isOpen, openModal, closeModal } = useModal(args.isOpen);
+
+    return (
+      <div className="flex flex-col items-center gap-2">
+        <button onClick={openModal} className="rounded-2xl bg-[#3E3F48] px-16 py-3 text-white">
+          모달 열기
+        </button>
+
+        <Modal {...args} isOpen={isOpen} closeModal={closeModal}>
+          <div className="flex flex-col items-center gap-2 rounded-2xl bg-white p-5 shadow-sm">
+            <Image src="/assets/ico-alert.svg" alt="alert 아이콘" width={60} height={60} />
+            <div className="flex flex-col items-center justify-center pb-4">
+              <span className="text-xl font-semibold">작성 중인 메모를</span>
+              <div className="flex flex-row">
+                <span className="text-xl font-semibold text-[#669AFF]">삭제</span>
+                <span className="text-xl font-semibold">하고 나가시겠어요?</span>
+              </div>
+            </div>
+
+            <div className="flex flex-row gap-2">
+              <button
+                className="rounded-2xl bg-[#E6E6E6] px-16 py-3 whitespace-nowrap text-[#878787]"
+                onClick={closeModal}
+              >
+                취소
+              </button>
+              <button
+                className="rounded-2xl bg-[#3E3F48] px-16 py-3 whitespace-nowrap text-white"
+                onClick={closeModal}
+              >
+                삭제하기
+              </button>
+            </div>
+          </div>
+        </Modal>
+      </div>
+    );
+  },
+};

--- a/src/components/ui/Modal/Modal.tsx
+++ b/src/components/ui/Modal/Modal.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+import { Portal } from '../Portal';
+
+type Props = {
+  isOpen: boolean;
+  closeModal: () => void;
+  children: React.ReactNode;
+};
+
+export function Modal({ isOpen, closeModal, children }: Props) {
+  return (
+    <Portal isOpen={isOpen}>
+      <div className="absolute inset-0 z-30 bg-black opacity-50" onClick={closeModal} />
+      <div className="pointer-events-none absolute inset-0 z-40 flex items-center justify-center">
+        <div className="pointer-events-auto rounded-2xl bg-white">{children}</div>
+      </div>
+    </Portal>
+  );
+}

--- a/src/components/ui/Modal/index.ts
+++ b/src/components/ui/Modal/index.ts
@@ -1,0 +1,1 @@
+export { Modal } from './Modal';

--- a/src/components/ui/Portal/Portal.tsx
+++ b/src/components/ui/Portal/Portal.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+import ReactDOM from 'react-dom';
+type Props = {
+  isOpen: boolean;
+  children: React.ReactNode;
+};
+export function Portal({ isOpen, children }: Props) {
+  const [mounted, setMounted] = React.useState(false);
+
+  React.useEffect(() => {
+    setMounted(true);
+    return () => setMounted(false);
+  }, []);
+
+  return mounted && isOpen ? ReactDOM.createPortal(children, document.body) : null;
+}

--- a/src/components/ui/Portal/index.tsx
+++ b/src/components/ui/Portal/index.tsx
@@ -1,0 +1,1 @@
+export { Portal } from './Portal';

--- a/src/hooks/useModal.tsx
+++ b/src/hooks/useModal.tsx
@@ -1,0 +1,11 @@
+import { useState } from 'react';
+
+export default function useModal(initialState = false) {
+  const [isOpen, setIsOpen] = useState(initialState);
+
+  const openModal = () => setIsOpen(true);
+  const closeModal = () => setIsOpen(false);
+  const toggleModal = () => setIsOpen((prev) => !prev);
+
+  return { isOpen, openModal, closeModal, toggleModal };
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1375,6 +1375,13 @@
   dependencies:
     fast-glob "3.3.1"
 
+"@next/eslint-plugin-next@^15.4.6":
+  version "15.4.6"
+  resolved "https://registry.yarnpkg.com/@next/eslint-plugin-next/-/eslint-plugin-next-15.4.6.tgz#d55ced8c7d2bb8f95496fa410331da1df31f3b9b"
+  integrity sha512-2NOu3ln+BTcpnbIDuxx6MNq+pRrCyey4WSXGaJIyt0D2TYicHeO9QrUENNjcf673n3B1s7hsiV5xBYRCK1Q8kA==
+  dependencies:
+    fast-glob "3.3.1"
+
 "@next/swc-darwin-arm64@15.4.4":
   version "15.4.4"
   resolved "https://registry.yarnpkg.com/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.4.4.tgz#e8791e3ddb6098f2e82c5fb574a7259641d92949"


### PR DESCRIPTION
## 🚀 기능 추가
- 모달 컴포넌트 개발

## 🏗 작업 내용 

- [x] 모달 컴포넌트 개발
- [x] Portal 컴포넌트 개발
- [x] useModal 훅 개발

- 아직 useModal 기능이 간단하게 밖에 없지만 필요에 따라 추가될 예정입니다
- storybook에서는 아이콘을 이미지 태그로 그대로 사용하거나 버튼태그를 사용하여 제작하였는데 아직 컴포넌트가 없어서 임의로 제작했다는 점 말씀드립니다
- eslint 설정에서 ESLint 9.x 버전에서 설정 형식이 변경되어 오류 발생하는 문제로 코드를 수정하였습니다

## 🔍 테스트 방법 | 🧪 테스트 체크리스트 

1. yarn storybook

## 👀 관련 이슈 번호

- close #17 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 새로운 모달(Modal) 컴포넌트와 포털(Portal) 컴포넌트가 추가되었습니다.
  * 모달의 열림/닫힘 상태를 관리하는 useModal 훅이 도입되었습니다.
  * Modal 컴포넌트의 사용 예시가 Storybook에 추가되었습니다.

* **Chores**
  * ESLint 설정이 개선되어 코드 스타일 및 포맷팅 규칙이 강화되었습니다.
  * 관련 ESLint 및 Prettier 플러그인 의존성이 추가되었습니다.

* **Style**
  * 불필요한 공백 라인이 제거되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->