### PR TITLE
feat: 인증 가드 도입 및 비로그인 처리 개선

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,47 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+const API_ORIGIN_ENV = process.env.NEXT_PUBLIC_BASE_URL;
+
+function apiUrl(req: NextRequest, path: string) {
+  const origin = API_ORIGIN_ENV ?? new URL(req.url).origin;
+  return `${origin}${path}`;
+}
+
+async function verifyAuth(req: NextRequest): Promise<boolean> {
+  const cookieHeader = req.headers.get('cookie');
+  if (!cookieHeader) return false;
+
+  const controller = new AbortController();
+  const to = setTimeout(() => controller.abort(), 2500);
+
+  try {
+    const res = await fetch(apiUrl(req, '/api/auth/my'), {
+      headers: { cookie: cookieHeader, Accept: 'application/json' },
+      cache: 'no-store',
+      signal: controller.signal,
+    });
+    return res.ok; // 2xx만 통과
+  } catch {
+    return false;
+  } finally {
+    clearTimeout(to);
+  }
+}
+
+export async function middleware(request: NextRequest) {
+  const authed = await verifyAuth(request);
+
+  if (!authed) {
+    const loginUrl = new URL('/login', request.url);
+    const redirectPath = request.nextUrl.pathname + request.nextUrl.search;
+    loginUrl.searchParams.set('redirect', redirectPath);
+    return NextResponse.redirect(loginUrl);
+  }
+
+  return NextResponse.next();
+}
+
+// 보호할 페이지만 매칭 (정적/이미지 등 제외)
+export const config = {
+  matcher: ['/myPage', '/map/:path*', '/checklist', '/vote/:path*'],
+};

--- a/src/queries/user/useMyInfo.ts
+++ b/src/queries/user/useMyInfo.ts
@@ -3,8 +3,12 @@ import { myInfo } from '@/services/auth';
 import { MyInfoResponse } from '@/types/auth';
 
 export function useMyInfo() {
-  return useQuery<MyInfoResponse>({
+  return useQuery<MyInfoResponse | null>({
     queryKey: ['myInfo'],
     queryFn: myInfo,
+    retry: false,
+    staleTime: 60_000,
+    gcTime: 5 * 60_000,
+    refetchOnWindowFocus: false,
   });
 }

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -1,8 +1,16 @@
 import { api } from '@/lib/api/ky';
+import { HTTPError } from 'ky';
 import { MyInfoResponse, LogoutResponse } from '@/types/auth';
 
-export async function myInfo(): Promise<MyInfoResponse> {
-  return api.get('api/auth/my').json<MyInfoResponse>();
+export async function myInfo(): Promise<MyInfoResponse | null> {
+  try {
+    return await api.get('api/auth/my').json<MyInfoResponse>();
+  } catch (err) {
+    if (err instanceof HTTPError && err.response?.status === 401) {
+      return null;
+    }
+    return null;
+  }
 }
 
 export async function logout(): Promise<LogoutResponse> {


### PR DESCRIPTION
## 🚀 기능 추가 / 개선 사항 | 🐞 버그 수정 | 🛠 리팩토링 개요

- middleware: /myPage, /map, /checklist, /vote 보호 및 로그인 리다이렉트

- myInfo: 401 시 오류 대신 null 반환(무소음 처리)

- useMyInfo: retry/포커스 리패치 비활성화로 불필요한 재요청 방지 

## 👀 관련 이슈 번호

- close #74 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * 특정 페이지에 인증 미들웨어를 적용하고, 미인증 시 원래 경로를 포함해 로그인 페이지로 리디렉션합니다.
* 개선사항
  * 내 정보 조회 실패 시 오류 대신 빈 상태로 안전하게 처리하여 예기치 않은 중단을 줄였습니다.
  * 데이터 캐싱을 1분으로 조정하고, 창 포커스 시 자동 재요청과 자동 재시도를 비활성화해 불필요한 네트워크 요청을 줄였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->