### PR TITLE
[FEAT] query-key-factory 적용

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
     "prepare": "husky install"
   },
   "dependencies": {
+    "@lukemorales/query-key-factory": "^1.3.4",
     "@tanstack/react-query": "^5.84.0",
+    "@tanstack/react-query-devtools": "^5.87.4",
     "aos": "^2.3.4",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next';
 import './globals.css';
 import { QueryProvider } from '@/components/providers/query-provider';
 import { HouseMemoProvider } from '@/components/providers/house-memo-provider';
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { Toaster } from 'react-hot-toast';
 import IcoLogoAll from '@assets/ico-logo-all.svg';
 import IcoHouse from '@assets/login/lco-house.svg';
@@ -68,6 +69,7 @@ export default function RootLayout({
 
             {children}
             <Toaster position="top-center" reverseOrder={false} />
+            {process.env.NODE_ENV === 'development' && <ReactQueryDevtools initialIsOpen={false} />}
           </QueryProvider>
         </HouseMemoProvider>
       </body>

--- a/src/queries/checkList/index.ts
+++ b/src/queries/checkList/index.ts
@@ -1,0 +1,11 @@
+import { createQueryKeys } from '@lukemorales/query-key-factory';
+import { getChecklistInfo } from '@/services/checkList';
+import type { ChecklistResponse } from '@/types/checklist';
+
+export const checklist = createQueryKeys('checklist', {
+  all: null,
+  info: {
+    queryKey: null,
+    queryFn: (): Promise<ChecklistResponse> => getChecklistInfo(),
+  },
+});

--- a/src/queries/checkList/useChecklistInfo.ts
+++ b/src/queries/checkList/useChecklistInfo.ts
@@ -1,10 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
-import { getChecklistInfo } from '@/services/checkList';
-import { ChecklistResponse } from '@/types/checklist';
+import { queries } from '@/queries';
 
 export const useChecklistInfo = () => {
-  return useQuery<ChecklistResponse>({
-    queryKey: ['checklist'],
-    queryFn: getChecklistInfo,
-  });
+  return useQuery(queries.checklist.info);
 };

--- a/src/queries/checkList/useSendRequiredItems.ts
+++ b/src/queries/checkList/useSendRequiredItems.ts
@@ -2,16 +2,18 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { sendRequiredItems } from '@/services/checkList';
 import toast from 'react-hot-toast';
 import { TOAST_STYLES } from '@/utils/toastStyles';
+import { queries } from '@/queries';
 
 export function useSendRequiredItems() {
-  const queryClient = useQueryClient();
+  const qc = useQueryClient();
 
   return useMutation({
     mutationFn: sendRequiredItems,
     onSuccess: () => {
       toast.success('필수 항목이 저장되었습니다.', TOAST_STYLES.success);
-      queryClient.invalidateQueries({
-        queryKey: ['checklist'],
+
+      qc.invalidateQueries({
+        queryKey: queries.checklist.info.queryKey,
       });
     },
     onError: (error) => {

--- a/src/queries/index.ts
+++ b/src/queries/index.ts
@@ -1,0 +1,6 @@
+import { mergeQueryKeys } from '@lukemorales/query-key-factory';
+import { checklist } from './checkList';
+
+export const queries = mergeQueryKeys(checklist);
+// 필요 시 여기에 다른 feature keys도 추가: mergeQueryKeys(checklist, users, todos, ...)
+export type QueryKeys = typeof queries;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1357,6 +1357,11 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
+"@lukemorales/query-key-factory@^1.3.4":
+  version "1.3.4"
+  resolved "https://registry.yarnpkg.com/@lukemorales/query-key-factory/-/query-key-factory-1.3.4.tgz#d14001dbd781b024df93ca73bd785db590924486"
+  integrity sha512-A3frRDdkmaNNQi6mxIshsDk4chRXWoXa05US8fBo4kci/H+lVmujS6QrwQLLGIkNIRFGjMqp2uKjC4XsLdydRw==
+
 "@mdx-js/react@^3.0.0":
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/@mdx-js/react/-/react-3.1.0.tgz#c4522e335b3897b9a845db1dbdd2f966ae8fb0ed"
@@ -1872,6 +1877,18 @@
   version "5.85.5"
   resolved "https://registry.yarnpkg.com/@tanstack/query-core/-/query-core-5.85.5.tgz#c4adc126bb3a927e4d60280bf3cf62210700147c"
   integrity sha512-KO0WTob4JEApv69iYp1eGvfMSUkgw//IpMnq+//cORBzXf0smyRwPLrUvEe5qtAEGjwZTXrjxg+oJNP/C00t6w==
+
+"@tanstack/query-devtools@5.87.3":
+  version "5.87.3"
+  resolved "https://registry.yarnpkg.com/@tanstack/query-devtools/-/query-devtools-5.87.3.tgz#0cfff30823f837d6b9ead08f8d1b16459203fdb2"
+  integrity sha512-LkzxzSr2HS1ALHTgDmJH5eGAVsSQiuwz//VhFW5OqNk0OQ+Fsqba0Tsf+NzWRtXYvpgUqwQr4b2zdFZwxHcGvg==
+
+"@tanstack/react-query-devtools@^5.87.4":
+  version "5.87.4"
+  resolved "https://registry.yarnpkg.com/@tanstack/react-query-devtools/-/react-query-devtools-5.87.4.tgz#278fe66c5263eff82178ad38f117a8c29d726714"
+  integrity sha512-JYcnVJBBW1DCPyNGM0S2CyrLpe6KFiL2gpYd/k9tAp62Du7+Y27zkzd+dKFyxpFadYaTxsx4kUA7YvnkMLVUoQ==
+  dependencies:
+    "@tanstack/query-devtools" "5.87.3"
 
 "@tanstack/react-query@^5.84.0":
   version "5.85.5"


### PR DESCRIPTION
## 🚀 기능 추가 

**배경**
- 각 쿼리에서 queryKey와 queryFn을 따로 선언하다 보니 응집도가 떨어짐
- 쿼리 키 네이밍이 일관되지 않아 무효화 범위 파악이 어렵고 중복 선언이 많음
[정리 자료](https://jasper-foam-5a0.notion.site/26db87ed31df806ca134eb9c65d6b183)

## 🏗 작업 내용 
- checklist 쿼리 키를 Query Key Factory 기반으로 리팩토링했습니다
- useChecklistInfo, useSendRequiredItems 훅을 queries.checklist.* API로 일관되게 변경했습니다
- queries/index.ts에서 mergeQueryKeys로 통합 관리
- react query devtools 설치
- 추가적으로 다른 api는 작업해주시면서 같이 적용해주시면 될거같습니다 현재는 checklist만 적용돼있습니다

## 👀 관련 이슈 번호

- close #101 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 개발 모드에서 React Query Devtools 제공(프로덕션에는 노출되지 않음).
- 리팩터
  - 쿼리 키를 중앙에서 관리하도록 구조 개선.
  - 체크리스트 관련 훅과 쿼리 무효화 로직을 통일해 일관성 및 유지보수성 향상.
- 잡무(Chores)
  - 개발 및 데이터 페칭 체계 강화를 위한 의존성 추가.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->